### PR TITLE
Update package name to coreui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "button-kit",
+  "name": "coreui",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Changed the package name from 'button-kit' to 'coreui' in package.json to reflect the new project identity.